### PR TITLE
Add dynamic strategy selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ trading_bot_template/
 - **bot.py**: Punto de entrada; carga configuración, inicializa estrategia y ejecución.
 - **config.yml**: Parámetros de API y bot (símbolo, timeframe, gestión de riesgo).
 - **config.py**: Función para cargar archivos YAML.
-- **strategy.py**: Clase abstracta `Strategy` y ejemplo de estrategia.
+- **strategy.py**: Contiene la clase abstracta `Strategy` y varias estrategias
+  de ejemplo listas para usar.
 - **execution.py**: Motor de ejecución usando CCXT para órdenes de mercado.
 - **logger.py**: Configuración de logging.
 - **backtest.py**: Plantilla para futuras funcionalidades de backtesting.
@@ -37,3 +38,18 @@ trading_bot_template/
    ```
    python bot.py
    ```
+4. Selecciona la estrategia en `config.yml` dentro de `bot.strategy.name`.
+   Las disponibles son `trend`, `grid`, `mean` y `auto`.
+   - **trend**: seguimiento de tendencia usando medias móviles.
+     Ajusta `short_window` y `long_window`.
+   - **grid**: grid trading dentro de un rango con `grid_lower`,
+     `grid_upper` y `grid_step`.
+   - **mean**: reversión a la media con RSI; configura
+     `rsi_period`, `overbought` y `oversold`.
+   - **auto**: selección dinámica de estrategia según el mercado.
+     Ajusta `auto_trend_threshold` para determinar cuándo considerar tendencia.
+   No olvides rellenar tus claves de API.
+
+## Advertencia
+
+Este proyecto es un ejemplo educativo. Opera bajo tu propia responsabilidad.

--- a/bot.py
+++ b/bot.py
@@ -1,14 +1,28 @@
 import time
 import logging
 from config import load_config
-from strategy import ExampleStrategy
+from strategy import (
+    TrendFollowingStrategy,
+    GridTradingStrategy,
+    MeanReversionStrategy,
+    AutoStrategy,
+)
 from execution import ExecutionEngine
 from logger import setup_logger
 
 def main():
     config = load_config('config.yml')
     logger = setup_logger()
-    strategy = ExampleStrategy(config)
+    strat_cfg = config['bot'].get('strategy', {})
+    name = strat_cfg.get('name', 'trend')
+    if name == 'grid':
+        strategy = GridTradingStrategy(config)
+    elif name == 'mean':
+        strategy = MeanReversionStrategy(config)
+    elif name == 'auto':
+        strategy = AutoStrategy(config)
+    else:
+        strategy = TrendFollowingStrategy(config)
     executor = ExecutionEngine(config, logger)
 
     logger.info('Bot de trading iniciado')

--- a/config.yml
+++ b/config.yml
@@ -11,3 +11,14 @@ bot:
     max_position_size: 0.01
     take_profit: 0.01
     stop_loss: 0.005
+  strategy:
+    name: 'trend'
+    short_window: 5
+    long_window: 20
+    grid_lower: 50000
+    grid_upper: 60000
+    grid_step: 500
+    rsi_period: 14
+    overbought: 70
+    oversold: 30
+    auto_trend_threshold: 0.01

--- a/execution.py
+++ b/execution.py
@@ -6,14 +6,18 @@ class ExecutionEngine:
         self.exchange = exchange_cls({
             'apiKey': config['api']['api_key'],
             'secret': config['api']['api_secret'],
+            'enableRateLimit': True,
         })
         self.logger = logger
 
     def execute(self, signal):
-        order = self.exchange.create_order(
-            symbol=signal['symbol'],
-            type='market',
-            side=signal['side'],
-            amount=signal['amount']
-        )
-        self.logger.info(f'Orden ejecutada: {order}')
+        try:
+            order = self.exchange.create_order(
+                symbol=signal['symbol'],
+                type='market',
+                side=signal['side'],
+                amount=signal['amount']
+            )
+            self.logger.info(f'Orden ejecutada: {order}')
+        except Exception as e:
+            self.logger.error(f'Error al ejecutar orden: {e}')

--- a/strategy.py
+++ b/strategy.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+import ccxt
+import numpy as np
 
 class Strategy(ABC):
     def __init__(self, config):
@@ -9,7 +11,159 @@ class Strategy(ABC):
         """Debe retornar dict{'symbol','side','amount'} o None."""
         pass
 
-class ExampleStrategy(Strategy):
+class TrendFollowingStrategy(Strategy):
+    def __init__(self, config):
+        super().__init__(config)
+        exchange_cls = getattr(ccxt, config['api']['exchange'])
+        self.exchange = exchange_cls({
+            'apiKey': config['api']['api_key'],
+            'secret': config['api']['api_secret'],
+        })
+        self.symbol = config['bot']['symbol']
+        self.timeframe = config['bot']['timeframe']
+        strat_cfg = config['bot'].get('strategy', {})
+        self.short_window = strat_cfg.get('short_window', 5)
+        self.long_window = strat_cfg.get('long_window', 20)
+        self.position = None
+
     def generate_signal(self):
-        # Ejemplo: sin lógica, siempre retorna None
+        limit = self.long_window + 1
+        try:
+            ohlcv = self.exchange.fetch_ohlcv(self.symbol, timeframe=self.timeframe, limit=limit)
+        except Exception:
+            return None
+        close_prices = [c[4] for c in ohlcv]
+        short_sma = np.mean(close_prices[-self.short_window:])
+        long_sma = np.mean(close_prices[-self.long_window:])
+
+        if short_sma > long_sma and self.position != 'long':
+            self.position = 'long'
+            amount = self.config['bot']['risk']['max_position_size']
+            return {'symbol': self.symbol, 'side': 'buy', 'amount': amount}
+        elif short_sma < long_sma and self.position != 'short':
+            self.position = 'short'
+            amount = self.config['bot']['risk']['max_position_size']
+            return {'symbol': self.symbol, 'side': 'sell', 'amount': amount}
         return None
+
+class GridTradingStrategy(Strategy):
+    """Estrategia simple de grid trading."""
+    def __init__(self, config):
+        super().__init__(config)
+        exchange_cls = getattr(ccxt, config['api']['exchange'])
+        self.exchange = exchange_cls({
+            'apiKey': config['api']['api_key'],
+            'secret': config['api']['api_secret'],
+        })
+        self.symbol = config['bot']['symbol']
+        self.timeframe = config['bot']['timeframe']
+        strat_cfg = config['bot'].get('strategy', {})
+        self.lower = strat_cfg.get('grid_lower', 50000)
+        self.upper = strat_cfg.get('grid_upper', 60000)
+        self.step = strat_cfg.get('grid_step', 500)
+        self.grid = list(np.arange(self.lower, self.upper + self.step, self.step))
+        self.last_level = None
+
+    def _current_level(self, price):
+        levels = [lvl for lvl in self.grid if lvl <= price]
+        return levels[-1] if levels else self.grid[0]
+
+    def generate_signal(self):
+        try:
+            ohlcv = self.exchange.fetch_ohlcv(self.symbol, timeframe=self.timeframe, limit=2)
+        except Exception:
+            return None
+        price = ohlcv[-1][4]
+        level = self._current_level(price)
+        if self.last_level is None:
+            self.last_level = level
+            return None
+        amount = self.config['bot']['risk']['max_position_size']
+        if level > self.last_level:
+            self.last_level = level
+            return {'symbol': self.symbol, 'side': 'sell', 'amount': amount}
+        elif level < self.last_level:
+            self.last_level = level
+            return {'symbol': self.symbol, 'side': 'buy', 'amount': amount}
+        return None
+
+class MeanReversionStrategy(Strategy):
+    """Estrategia simple de reversión a la media basada en RSI."""
+    def __init__(self, config):
+        super().__init__(config)
+        exchange_cls = getattr(ccxt, config['api']['exchange'])
+        self.exchange = exchange_cls({
+            'apiKey': config['api']['api_key'],
+            'secret': config['api']['api_secret'],
+        })
+        self.symbol = config['bot']['symbol']
+        self.timeframe = config['bot']['timeframe']
+        strat_cfg = config['bot'].get('strategy', {})
+        self.period = strat_cfg.get('rsi_period', 14)
+        self.overbought = strat_cfg.get('overbought', 70)
+        self.oversold = strat_cfg.get('oversold', 30)
+
+    def _rsi(self, prices):
+        deltas = np.diff(prices)
+        ups = np.where(deltas > 0, deltas, 0)
+        downs = np.where(deltas < 0, -deltas, 0)
+        roll_up = np.mean(ups[-self.period:])
+        roll_down = np.mean(downs[-self.period:])
+        rs = roll_up / (roll_down + 1e-9)
+        return 100 - (100 / (1 + rs))
+
+    def generate_signal(self):
+        limit = self.period + 1
+        try:
+            ohlcv = self.exchange.fetch_ohlcv(self.symbol, timeframe=self.timeframe, limit=limit)
+        except Exception:
+            return None
+        prices = [c[4] for c in ohlcv]
+        rsi = self._rsi(prices)
+        amount = self.config['bot']['risk']['max_position_size']
+        if rsi > self.overbought:
+            return {'symbol': self.symbol, 'side': 'sell', 'amount': amount}
+        elif rsi < self.oversold:
+            return {'symbol': self.symbol, 'side': 'buy', 'amount': amount}
+        return None
+
+class AutoStrategy(Strategy):
+    """Selecciona la mejor estrategia según el estado del mercado."""
+    def __init__(self, config):
+        super().__init__(config)
+        self.trend = TrendFollowingStrategy(config)
+        self.grid = GridTradingStrategy(config)
+        self.mean = MeanReversionStrategy(config)
+        strat_cfg = config["bot"].get("strategy", {})
+        self.threshold = strat_cfg.get("auto_trend_threshold", 0.01)
+
+    def _detect_state(self):
+        limit = max(self.trend.long_window, self.mean.period) + 1
+        try:
+            ohlcv = self.trend.exchange.fetch_ohlcv(self.trend.symbol, timeframe=self.trend.timeframe, limit=limit)
+        except Exception:
+            return "grid"
+        prices = [c[4] for c in ohlcv]
+        short_sma = np.mean(prices[-self.trend.short_window:])
+        long_sma = np.mean(prices[-self.trend.long_window:])
+        diff = abs(short_sma - long_sma) / (long_sma + 1e-9)
+        deltas = np.diff(prices[-(self.mean.period + 1):])
+        ups = np.where(deltas > 0, deltas, 0)
+        downs = np.where(deltas < 0, -deltas, 0)
+        roll_up = np.mean(ups[-self.mean.period:])
+        roll_down = np.mean(downs[-self.mean.period:])
+        rs = roll_up / (roll_down + 1e-9)
+        rsi = 100 - (100 / (1 + rs))
+        if diff > self.threshold:
+            return "trend"
+        if rsi > self.mean.overbought or rsi < self.mean.oversold:
+            return "mean"
+        return "grid"
+
+    def generate_signal(self):
+        state = self._detect_state()
+        if state == "trend":
+            return self.trend.generate_signal()
+        elif state == "mean":
+            return self.mean.generate_signal()
+        return self.grid.generate_signal()


### PR DESCRIPTION
## Summary
- implement `AutoStrategy` to select grid, trend or mean strategy automatically
- add auto strategy option in config and README
- support `auto` strategy in `bot.py`

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6845d56ac8a88320bb740cdd61eb089c